### PR TITLE
truncate vs. round 🤷‍♂️

### DIFF
--- a/viz_pbi-server/README.md
+++ b/viz_pbi-server/README.md
@@ -7,6 +7,8 @@ Scripts for loading data in PowerBI: [https://github.com/yschindel/NHMzh-pbi-que
 This is a server for providing data for a PowerBi dashboard. All data is stored in MinIO as .parquet files.
 The file paths are project/file. The directory structure is an important part of the information in the system as it is used to inform the PowerBi dashboard of the data that is available.
 
+All timestamps written to the backing SQL database are rounded to **0.1‑second** precision before being persisted.
+
 ## Security Features
 
 ### API Key Authentication

--- a/viz_pbi-server/storage/azure/sqlWriter.go
+++ b/viz_pbi-server/storage/azure/sqlWriter.go
@@ -94,13 +94,13 @@ func (w *SqlWriter) writeElementsWithRetry(items []models.EavElementDataItem) er
 		)
 		for _, item := range batch {
 			params := []string{}
-			// Parse and truncate timestamp to 1 decimal place to match DATETIME2(1)
-			timestamp, err := time.Parse(time.RFC3339, item.Timestamp)
+			// Parse and round timestamp to 1 decimal place to match DATETIME2(1)
+			timestamp, err := time.Parse(time.RFC3339Nano, item.Timestamp)
 			if err != nil {
 				log.WithFields(logger.Fields{"error": err, "timestamp": item.Timestamp}).Error("Error parsing timestamp")
 				return fmt.Errorf("error parsing timestamp: %v", err)
 			}
-			truncatedTimestamp := timestamp.Truncate(time.Millisecond * 100)
+			truncatedTimestamp := timestamp.Round(time.Millisecond * 100)
 			for _, val := range []interface{}{
 				item.Project, item.Filename, truncatedTimestamp, item.Id, item.ParamName,
 				item.ParamValueString, item.ParamValueNumber, item.ParamValueBoolean, item.ParamValueDate, item.ParamType,
@@ -191,13 +191,13 @@ func (w *SqlWriter) writeMaterialsWithRetry(items []models.EavMaterialDataItem) 
 		)
 		for _, item := range batch {
 			params := []string{}
-			// Parse and truncate timestamp to 1 decimal place to match DATETIME2(1)
-			timestamp, err := time.Parse(time.RFC3339, item.Timestamp)
+			// Parse and round timestamp to 1 decimal place to match DATETIME2(1)
+			timestamp, err := time.Parse(time.RFC3339Nano, item.Timestamp)
 			if err != nil {
 				log.WithFields(logger.Fields{"error": err, "timestamp": item.Timestamp}).Error("Error parsing timestamp")
 				return fmt.Errorf("error parsing timestamp: %v", err)
 			}
-			truncatedTimestamp := timestamp.Truncate(time.Millisecond * 100)
+			truncatedTimestamp := timestamp.Round(time.Millisecond * 100)
 			for _, val := range []interface{}{
 				item.Project, item.Filename, truncatedTimestamp, item.Id, item.Sequence, item.ParamName,
 				item.ParamValueString, item.ParamValueNumber, item.ParamValueBoolean, item.ParamValueDate, item.ParamType,

--- a/viz_pbi-server/storage/azure/sqlWriter_test.go
+++ b/viz_pbi-server/storage/azure/sqlWriter_test.go
@@ -1,0 +1,33 @@
+package azure
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTimestampRounding(t *testing.T) {
+	cases := []struct {
+		in   string
+		want time.Time
+	}{
+		{
+			in:   "2023-01-01T12:00:00.249Z",
+			want: time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC).Add(200 * time.Millisecond),
+		},
+		{
+			in:   "2023-01-01T12:00:00.251Z",
+			want: time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC).Add(300 * time.Millisecond),
+		},
+	}
+
+	for _, c := range cases {
+		ts, err := time.Parse(time.RFC3339Nano, c.in)
+		if err != nil {
+			t.Fatalf("failed to parse timestamp %s: %v", c.in, err)
+		}
+		got := ts.Round(time.Millisecond * 100)
+		if !got.Equal(c.want) {
+			t.Errorf("rounded %s got %s want %s", c.in, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Parse and round timestamp to 1 decimal place with time.Parse(time.RFC3339Nano... to match DATETIME2(1) 